### PR TITLE
[SDK-966]: Add Lottie dependency to Swift package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,11 +11,22 @@ let package = Package(
     products: [
         .library(
           name: "StorytellerSDK",
-          targets: ["StorytellerSDK"]),
+          targets: [
+            "StorytellerSDK",
+            "StorytellerSDKDependencies"
+          ]),
+    ],
+    dependencies: [
+      .package(url: "https://github.com/airbnb/lottie-spm.git", .upToNextMajor(from: "4.5.2")),
     ],
     targets: [
       .binaryTarget(name: "StorytellerSDK",
                     url: "https://storyteller.azureedge.net/sdk-ios/xcframeworks/11.3.3/StorytellerSDK.zip",
-                    checksum: "6bb6ba04c852fed2e3ab874f35a10a93b42adf2845aebe72547e78722fd756bf")
+                    checksum: "6bb6ba04c852fed2e3ab874f35a10a93b42adf2845aebe72547e78722fd756bf"),
+      .target(
+        name: "StorytellerSDKDependencies",
+        dependencies: [
+          .product(name: "Lottie", package: "lottie-spm")
+        ])
     ]
 )

--- a/Sources/StorytellerSDKDependencies/Empty.swift
+++ b/Sources/StorytellerSDKDependencies/Empty.swift
@@ -1,0 +1,1 @@
+// This file needs to be here only so that the package passes validation

--- a/Sources/StorytellerSDKDependencies/StorytellerSDKDependencies.swift
+++ b/Sources/StorytellerSDKDependencies/StorytellerSDKDependencies.swift
@@ -1,7 +1,0 @@
-import Lottie
-
-enum StorytellerSDKDependencies {
-    static func lottieAnimationViewType() -> Any.Type {
-        LottieAnimationView.self
-    }
-}

--- a/Sources/StorytellerSDKDependencies/StorytellerSDKDependencies.swift
+++ b/Sources/StorytellerSDKDependencies/StorytellerSDKDependencies.swift
@@ -1,0 +1,7 @@
+import Lottie
+
+enum StorytellerSDKDependencies {
+    static func lottieAnimationViewType() -> Any.Type {
+        LottieAnimationView.self
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the `lottie-spm` package dependency using `.upToNextMajor(from: "4.5.2")`.
- Keeps the public `StorytellerSDK` product name unchanged while adding a small `StorytellerSDKDependencies` source target alongside the existing binary target.
- Uses an `Empty.swift` placeholder in the dependency target, matching the existing GAM Swift package wrapper-target convention.

## Linear

- [SDK-966](https://linear.app/getstoryteller/issue/SDK-966/ios-or-spm-or-add-lottie-dependency-to-sdk-swift-package-repo)
- Related source repo fix: [SDK-962](https://linear.app/getstoryteller/issue/SDK-962/ios-fix-lottie-dependency-packaging)

## Validation

- `swift package describe --type json`
- `xcodebuild -scheme storyteller-sdk -destination 'generic/platform=iOS' -sdk iphoneos build`
