### PR TITLE
[SDK-1054]: Use StorytellerLottie in Swift package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
           ]),
     ],
     dependencies: [
-      .package(url: "https://github.com/airbnb/lottie-spm.git", .upToNextMajor(from: "4.5.2")),
+      .package(url: "https://github.com/getstoryteller/storyteller-lottie-module-swift", exact: "4.6.0"),
     ],
     targets: [
       .binaryTarget(name: "StorytellerSDK",
@@ -26,7 +26,7 @@ let package = Package(
       .target(
         name: "StorytellerSDKDependencies",
         dependencies: [
-          .product(name: "Lottie", package: "lottie-spm")
+          .product(name: "StorytellerLottie", package: "storyteller-lottie-module-swift")
         ])
     ]
 )


### PR DESCRIPTION
## Summary

- Updates the StorytellerSDK Swift package to use `StorytellerLottie` `4.6.0`.
- Replaces the previous direct Airbnb Lottie package dependency.

## Validation

- `swift package dump-package`
